### PR TITLE
Updated 5.1.8 to create at.allow file if does not exist

### DIFF
--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -86,11 +86,13 @@
       - id_5.1.8
 
 - name: "5.1.8 | Ensure at/cron is restricted to authorized users"
-  file:
+  copy:
       dest: /etc/cron.allow
       owner: root
       group: root
       mode: 0600
+      content: ""
+      force: no
   tags:
       - id_5.1.8
 

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -68,11 +68,13 @@
       - id_5.1.8
 
 - name: "5.1.8 | Ensure at/cron is restricted to authorized users"
-  file:
+  copy:
       dest: /etc/at.allow
       owner: root
       group: root
       mode: 0600
+      content: ""
+      force: no
   tags:
       - id_5.1.8
 


### PR DESCRIPTION
Using the copy command to create the At.allow file if it does not exist instead of the file touch command. 